### PR TITLE
update version, deps, links

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -4,9 +4,3 @@ channel_targets:
 - nsls2forge main
 docker_image:
 - condaforge/linux-anvil-comp7
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- '3.6'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "71ff135326e43361e8a27a8f75666d0a103e1a54e29e83959c069af4bf5b937f" %}
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
-{% set version = "1.10.0" %}
+{% set version = "1.11.1" %}
 
 package:
   name: event-model
   version: {{ version }}
 
 source:
-  git_url: https://github.com/NSLS-II/event-model
-  git_rev: v{{ version }}
+  url: https://github.com/bluesky/event-model/archive/v{{ version }}.tar.gz
+  fn: event-model-v{{version}}.tar.gz
+  sha256: 71ff135326e43361e8a27a8f75666d0a103e1a54e29e83959c069af4bf5b937f
 
 build:
   noarch: python
@@ -15,14 +16,12 @@ build:
   
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
-    - pytest
-    - pytest-runner
   run:
-    - jsonschema >=3.0.0
+    - python >=3.6
+    - jsonschema 
     - numpy
-    - python
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,6 @@ about:
 
 extra:
   recipe-maintainers:
-    - CJ-Wright
     - danielballan
     - ericdill
     - licode

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,14 @@
+{% set name = "event-model" %}
 {% set version = "1.11.1" %}
+{% set sha256 = "71ff135326e43361e8a27a8f75666d0a103e1a54e29e83959c069af4bf5b937f" %}
 
 package:
-  name: event-model
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/bluesky/event-model/archive/v{{ version }}.tar.gz
-  fn: event-model-v{{version}}.tar.gz
-  sha256: 71ff135326e43361e8a27a8f75666d0a103e1a54e29e83959c069af4bf5b937f
+  url: https://github.com/bluesky/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   noarch: python


### PR DESCRIPTION
This PR is to update the version of `event-model` according to the conda-forge feedstock for this package. Additionally, dependency pinnings and urls in the recipe were updated. 