### PR TITLE
Use conda-forge's docker image again & rerender

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: nsls2/nsls2forge:latest
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,4 +5,4 @@ channel_sources:
 channel_targets:
 - nsls2forge main
 docker_image:
-- nsls2/nsls2forge:latest
+- quay.io/condaforge/linux-anvil-comp7

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,10 +4,6 @@ channel_targets:
   - nsls2forge main
 cdt_name:
   - cos6
-cuda_compiler_version:
-  - None
-docker_image:
-  - nsls2/nsls2forge:latest
 numpy:
   - 1.16
 python:


### PR DESCRIPTION
We better stick with CF's Docker images, as the images are updated faster in case of errors (e.g., see https://github.com/conda-forge/docker-images/pull/166 for the fix for the broken yum repos). The [only customization](https://github.com/nsls-ii-forge/utils/blob/436d8a0aa1e98a1a3741f470ef360b88e6dc7855/nsls2forge-docker/Dockerfile#L5) we were using in our [custom image](https://hub.docker.com/r/nsls2/nsls2forge) was accepted and merged back in August 2020 (https://github.com/conda-forge/docker-images/pull/142), so the CF images work well with non-CF channels.